### PR TITLE
Bind Android notification delete intent only for ANCS ‘Clear’ actions

### DIFF
--- a/app/src/main/java/moe/reimu/ancsreceiver/ancs/AncsConstants.kt
+++ b/app/src/main/java/moe/reimu/ancsreceiver/ancs/AncsConstants.kt
@@ -8,3 +8,19 @@ object AncsConstants {
     const val NotificationAttributeIDPositiveActionLabel: Byte = 6
     const val NotificationAttributeIDNegativeActionLabel: Byte = 7
 }
+
+object AncsActionLabels {
+    private val CLEAR_STRINGS = setOf(
+        "Clear",
+        "清除"
+    ).map { it.uppercase() }.toSet()
+
+    /**
+     * Check if the given ANCS action label is a "Clear" action.
+     * The label is in the iPhone's language, so we compare against all supported translations.
+     */
+    fun isClearAction(actionLabel: String): Boolean {
+        return actionLabel.uppercase() in CLEAR_STRINGS
+    }
+}
+

--- a/app/src/main/java/moe/reimu/ancsreceiver/services/AncsService.kt
+++ b/app/src/main/java/moe/reimu/ancsreceiver/services/AncsService.kt
@@ -57,6 +57,7 @@ import moe.reimu.ancsreceiver.R
 import moe.reimu.ancsreceiver.ServiceState
 import moe.reimu.ancsreceiver.ams.AmsBleService
 import moe.reimu.ancsreceiver.ams.EntityUpdateNotification
+import moe.reimu.ancsreceiver.ancs.AncsActionLabels
 import moe.reimu.ancsreceiver.ancs.AncsBleService
 import moe.reimu.ancsreceiver.ancs.AppAttributeRequest
 import moe.reimu.ancsreceiver.ancs.AttributeRequest
@@ -375,7 +376,16 @@ class AncsService : Service() {
                                 negativeAction,
                                 getActionIntent(ACTION_NEGATIVE_ACTION, uid)
                             )
-                            builder.setDeleteIntent(getActionIntent(ACTION_NEGATIVE_ACTION, uid))
+
+                            // Set delete intent only when the negative action is "Clear"
+                            if (AncsActionLabels.isClearAction(negativeAction)) {
+                                builder.setDeleteIntent(
+                                    getActionIntent(
+                                        ACTION_NEGATIVE_ACTION,
+                                        uid
+                                    )
+                                )
+                            }
                         }
 
                         val contentLines = mutableListOf<String>()


### PR DESCRIPTION
Hi @kmod-midori ,

Thanks for the great work on CatConnect! it's such a fantastic tool and makes my life a lot easier.

I noticed a small issue: When forwarding notifications from iOS to Android, clearing a notification on the Android side will end active calls on the iPhone.

I’ve updated the logic to only bind Android’s notification delete intent to the ANCS negative action **when the negative action is 'Clear'.**  

I think this change helps prevent inadvertent actions, but I’d love to hear your thoughts. 

Please also let me know if the implementation looks good to you. Determining whether a negative action is 'Clear' is a bit tricky since the label is always in iPhone's system language.

Thanks again :)