### PR TITLE
Fix new media session not being saved

### DIFF
--- a/app/src/main/java/moe/reimu/ancsreceiver/services/AncsService.kt
+++ b/app/src/main/java/moe/reimu/ancsreceiver/services/AncsService.kt
@@ -656,18 +656,19 @@ class AncsService : Service() {
             }
 
             mediaSessionMutex.withLock {
-                val currentSession = mediaSession ?: MediaSessionCompat(this, "appleAms")
-                currentSession.apply {
+                if (mediaSession == null) {
+                    mediaSession = MediaSessionCompat(this, "appleAms")
+                }
+                mediaSession?.apply {
                     setCallback(sessionCallback, Handler(Looper.getMainLooper()))
                     setMetadata(metadata.build())
                     setPlaybackState(playbackStateCompat.build())
                     isActive = true
                 }
-                mediaStyle.setMediaSession(currentSession.sessionToken)
+                mediaStyle.setMediaSession(mediaSession?.sessionToken)
                 notification.setStyle(mediaStyle)
                 NotificationManagerCompat.from(this@AncsService)
                     .notify(NOTI_ID_MEDIA, notification.build())
-                mediaSession = currentSession
             }
         }
 


### PR DESCRIPTION
After creation, `MediaSessionCompat` isn't being properly saved to the class-level variable. So it doesn't get properly destroyed when music playing is stopped.

This PR fixes it.